### PR TITLE
Add collection group query generation

### DIFF
--- a/packages/builder/src/generate/entity/admin/generateListCollectionGroup.ts
+++ b/packages/builder/src/generate/entity/admin/generateListCollectionGroup.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import capitalize from 'lodash/capitalize';
+import { GenerateEntityProps } from '../../types';
+import generate from '../../generate';
+
+const generateListCollectionGroup = (props: GenerateEntityProps) => {
+    const { outdir, entityName, parents } = props;
+    generate({
+        templatePath: path.join(__dirname, '../../../templates/entity/admin/listCollectionGroup.hbs'),
+        targetPath: path.join(outdir, entityName, 'listCollectionGroup.ts'),
+        data: {
+            entityName,
+            entityInterface: capitalize(entityName),
+            parents,
+        },
+    });
+};
+
+export default generateListCollectionGroup;

--- a/packages/builder/src/generate/entity/generateListCollectionGroup.ts
+++ b/packages/builder/src/generate/entity/generateListCollectionGroup.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import capitalize from 'lodash/capitalize';
+import { GenerateEntityProps } from '../types';
+import generate from '../generate';
+
+const generateListCollectionGroup = (props: GenerateEntityProps) => {
+    const { outdir, entityName, parents } = props;
+    generate({
+        templatePath: path.join(__dirname, '../../templates/entity/listCollectionGroup.hbs'),
+        targetPath: path.join(outdir, entityName, 'listCollectionGroup.ts'),
+        data: {
+            entityName,
+            entityInterface: capitalize(entityName),
+            parents,
+        },
+    });
+};
+
+export default generateListCollectionGroup;

--- a/packages/builder/src/generate/entity/generateOnSnapshotCollectionGroup.ts
+++ b/packages/builder/src/generate/entity/generateOnSnapshotCollectionGroup.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import capitalize from 'lodash/capitalize';
+import { GenerateEntityProps } from '../types';
+import generate from '../generate';
+
+const generateOnSnapshotCollectionGroup = (props: GenerateEntityProps) => {
+    const { outdir, entityName, parents } = props;
+    generate({
+        templatePath: path.join(__dirname, '../../templates/entity/onSnapshotCollectionGroup.hbs'),
+        targetPath: path.join(outdir, entityName, 'onSnapshotCollectionGroup.ts'),
+        data: {
+            entityName,
+            entityInterface: capitalize(entityName),
+            parents,
+        },
+    });
+};
+
+export default generateOnSnapshotCollectionGroup;

--- a/packages/builder/src/generate/entity/generateUseCollectionGroup.ts
+++ b/packages/builder/src/generate/entity/generateUseCollectionGroup.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import capitalize from 'lodash/capitalize';
+import { GenerateEntityProps } from '../types';
+import generate from '../generate';
+
+const generateUseCollectionGroup = (props: GenerateEntityProps) => {
+    const { outdir, entityName, parents } = props;
+    generate({
+        templatePath: path.join(__dirname, '../../templates/entity/useCollectionGroup.hbs'),
+        targetPath: path.join(outdir, entityName, 'useCollectionGroup.ts'),
+        data: {
+            entityName,
+            entityInterface: capitalize(entityName),
+            parents,
+        },
+    });
+};
+
+export default generateUseCollectionGroup;

--- a/packages/builder/src/generate/generations.ts
+++ b/packages/builder/src/generate/generations.ts
@@ -5,13 +5,16 @@ import generateTypes from './entity/generateTypes';
 import generateUpdate from './entity/generateUpdate';
 import generateRemove from './entity/generateRemove';
 import generateList from './entity/generateList';
+import generateListCollectionGroup from './entity/generateListCollectionGroup';
 import generateCount from './entity/generateCount';
 import generatePaginate from './entity/generatePaginate';
 import generateOnSnapshotDoc from './entity/generateOnSnapshotDoc';
 import generateOnSnapshotCollection from './entity/generateOnSnapshotCollection';
+import generateOnSnapshotCollectionGroup from './entity/generateOnSnapshotCollectionGroup';
 import generateOnSnapshotPaginate from './entity/generateOnSnapshotPaginate';
 import generateUseDoc from './entity/generateUseDoc';
 import generateUseCollection from './entity/generateUseCollection';
+import generateUseCollectionGroup from './entity/generateUseCollectionGroup';
 import generateUseCollectionWithPagination from './entity/generateUseCollectionWithPagination';
 import generateUseCount from './entity/generateUseCount';
 
@@ -19,6 +22,7 @@ import generateUseCount from './entity/generateUseCount';
 import generateAdminTypes from './entity/admin/generateTypes';
 import generateAdminGet from './entity/admin/generateGet';
 import generateAdminList from './entity/admin/generateList';
+import generateAdminListCollectionGroup from './entity/admin/generateListCollectionGroup';
 import generateAdminPaginate from './entity/admin/generatePaginate';
 import generateAdminAdd from './entity/admin/generateAdd';
 import generateAdminRemove from './entity/admin/generateRemove';
@@ -42,14 +46,17 @@ export const entityCode = [
     generateUpdate,
     generateRemove,
     generateList,
+    generateListCollectionGroup,
     generateCount,
     generateOnSnapshotDoc,
     generateOnSnapshotCollection,
+    generateOnSnapshotCollectionGroup,
     generateOnSnapshotPaginate,
     generatePaginate,
     generateTypes,
     generateUseDoc,
     generateUseCollection,
+    generateUseCollectionGroup,
     generateUseCollectionWithPagination,
     generateUseDocOnce,
     generateUseCollectionOnce,
@@ -62,6 +69,7 @@ export const adminEntityCode = [
     generateAdminTypes,
     generateAdminGet,
     generateAdminList,
+    generateAdminListCollectionGroup,
     generateAdminPaginate,
     generateAdminAdd,
     generateAdminRemove,

--- a/packages/builder/src/templates/entity/admin/listCollectionGroup.hbs
+++ b/packages/builder/src/templates/entity/admin/listCollectionGroup.hbs
@@ -1,0 +1,23 @@
+import { db } from "../{{#each parents}}../{{/each}}admin";
+import { ListServiceOpts, EntityGet, EntityServerGet } from "../{{#each parents}}../{{/each}}types";
+import { transformMetadata, processTimestampFields } from '../{{#each parents}}./{{/each}}utils';
+import { {{entityInterface}} } from "./types";
+
+export type {{entityInterface}}CollectionGroupListService<T> = (opts?: ListServiceOpts) => Promise<Array<T>>;
+
+const listCollectionGroup: {{entityInterface}}CollectionGroupListService<EntityGet<{{entityInterface}}>> = async (opts = {}) => {
+  const collectionRef = db.collectionGroup("{{entityName}}");
+  const q =
+    typeof opts.listQueryFn === "function"
+      ? opts.listQueryFn(collectionRef as any)
+      : collectionRef;
+  const querySnapshot = await q.get();
+  return querySnapshot.docs.map((doc) => {
+    return processTimestampFields(transformMetadata({
+        ...doc.data(),
+        id: doc.id,
+    } as EntityServerGet<{{entityInterface}}>)) as EntityGet<{{entityInterface}}>;
+  });
+};
+
+export default listCollectionGroup;

--- a/packages/builder/src/templates/entity/listCollectionGroup.hbs
+++ b/packages/builder/src/templates/entity/listCollectionGroup.hbs
@@ -1,0 +1,26 @@
+import { collectionGroup, query, getDocs, getDocsFromServer, CollectionReference } from "firebase/firestore";
+import { db } from "../{{#each parents}}../{{/each}}firebase";
+import { EntityGet, EntityServerGet, ListServiceOpts } from "../{{#each parents}}../{{/each}}types";
+import { {{entityInterface}} } from "./types";
+import { transformMetadata, processTimestampFields } from '../{{#each parents}}./{{/each}}utils';
+
+export type {{entityInterface}}CollectionGroupListService<T> = (opts?: ListServiceOpts) => Promise<Array<T>>;
+
+const listCollectionGroup: {{entityInterface}}CollectionGroupListService<EntityGet<{{entityInterface}}>> = async (opts = {}) => {
+  const collectionRef = collectionGroup(db, "{{entityName}}");
+  const { disableCache } = opts;
+  const q =
+    typeof opts.listQueryFn === "function"
+      ? opts.listQueryFn(collectionRef as unknown as CollectionReference)
+      : query(collectionRef);
+  const getFn = disableCache ? getDocsFromServer : getDocs;
+  const querySnapshot = await getFn(q);
+  return querySnapshot.docs.map((doc) => {
+    return processTimestampFields(transformMetadata({
+        ...doc.data(),
+        id: doc.id,
+    } as EntityServerGet<{{entityInterface}}>)) as EntityGet<{{entityInterface}}>;
+  });
+};
+
+export default listCollectionGroup;

--- a/packages/builder/src/templates/entity/onSnapshotCollectionGroup.hbs
+++ b/packages/builder/src/templates/entity/onSnapshotCollectionGroup.hbs
@@ -1,0 +1,40 @@
+import { collectionGroup, onSnapshot, FirestoreError, query, Unsubscribe, CollectionReference } from "firebase/firestore";
+import { db } from "../{{#each parents}}../{{/each}}firebase";
+import { EntityGet, EntityServerGet, ListServiceOpts } from "../{{#each parents}}../{{/each}}types";
+import { {{entityInterface}} } from "./types";
+import { transformMetadata, processTimestampFields } from '../{{#each parents}}./{{/each}}utils';
+
+export type {{entityInterface}}OnSnapshotCollectionGroupService<T> = (opts: ListServiceOpts,callback: (docs: Array<T>) => void, onError?: (error: FirestoreError) => void) => Unsubscribe;
+
+const onSnapshotCollectionGroup: {{entityInterface}}OnSnapshotCollectionGroupService<EntityGet<{{entityInterface}}>> = (
+    opts: ListServiceOpts,
+    callback,
+    onError = () => {}
+) => {
+  const collectionRef = collectionGroup(db, "{{entityName}}");
+  const { disableCache } = opts;
+  const q = opts.listQueryFn
+    ? opts.listQueryFn(collectionRef as unknown as CollectionReference)
+    : query(collectionRef);
+  return onSnapshot(
+    q,
+    { includeMetadataChanges: disableCache },
+    (querySnap) => {
+      const { metadata } = querySnap;
+      const { fromCache } = metadata;
+      if (disableCache && fromCache) return;
+      callback(
+        querySnap.docs.map(
+          (doc) =>
+            (processTimestampFields(transformMetadata({
+              ...doc.data(),
+              id: doc.id,
+            } as EntityServerGet<{{entityInterface}}>, doc.metadata)) as EntityGet<{{entityInterface}}>)
+        )
+      );
+    },
+    onError
+  );
+};
+
+export default onSnapshotCollectionGroup;

--- a/packages/builder/src/templates/entity/useCollectionGroup.hbs
+++ b/packages/builder/src/templates/entity/useCollectionGroup.hbs
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { FirestoreError } from "firebase/firestore";
+import onSnapshotCollectionGroup from './onSnapshotCollectionGroup';
+import { {{entityInterface}} } from './types';
+import { EntityGet, HookCollectionOpts, HookReturnCollection } from '../{{#each parents}}../{{/each}}types';
+
+export type {{entityInterface}}UseCollectionGroupHook<T> = (opts?: HookCollectionOpts<T>) => HookReturnCollection<T>;
+
+
+const useCollectionGroup: {{entityInterface}}UseCollectionGroupHook<EntityGet<{{entityInterface}}>> = (opts = {}) => {
+  const [data, setData] = useState<Array<EntityGet<{{entityInterface}}>>>([]);
+  const [error, setError] = useState<FirestoreError | null>(null);
+  const [isLoading, setLoading] = useState(false);
+  const { disabled = false, onSnap, track = [] } = opts;
+  useEffect(() => {
+    if (!disabled) {
+        setLoading(true);
+        const unsub = onSnapshotCollectionGroup(opts || {}, (docs) => {
+            setData(docs);
+            setLoading(false);
+            if (typeof onSnap === 'function') {
+                onSnap(docs);
+            }
+          },
+          (error) => {
+            setLoading(false);
+            setError(error);
+          }
+        );
+        return () => {
+          setLoading(false);
+          unsub();
+        }
+    }
+  }, [disabled, ...track]);
+  return { data, error, isLoading };
+};
+
+export default useCollectionGroup;


### PR DESCRIPTION
## Summary
- support building collection group queries
- generate React hooks for collection group usage
- support admin collection group list service

## Testing
- `yarn lint` *(fails: RequestError tunneling socket could not be established)*